### PR TITLE
Sampling speed up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Datasets
+VOCSegmentation

--- a/README.md
+++ b/README.md
@@ -179,6 +179,23 @@ hbird_miou = hbird_evaluation(model.to(device),
 print('Dense NN Ret - miou score:', hbird_miou) 
 
 ```
+
+#### Ready to use script
+
+We also provide a ready to use Python script to run evaluations using DINO backbones. For example, to evaluate a ViT S/16 on the whole Pascal VOC dataset using a memory bank of size 1024*10<sup>2</sup> you can run the following command
+
+```sh
+python eval.py                  \
+    --seed 42                   \
+    --batch-size 64             \
+    --input-size 512            \
+    --patch-size 16             \
+    --memory-size 102400        \
+    --embeddings-size 384       \
+    --data-dir VOCSegmentation  \
+    --model dino_vits16
+```
+
 ###  Setup
 This is the section describing what is required to execute the Dense NN Retrieval Evaluation.
 
@@ -191,7 +208,9 @@ The most prevalent libraries being used:
 * `joblib`
 
 #### Dataset Setup
+
 ##### VOC Pascal
+
 We provide you with a zipped version of the whole dataset as well as with two smaller versions of it:
 * [Pascal VOC](https://1drv.ms/u/s!AnBBK4_o1T9MbXrxhV7BpGdS8tk?e=P7G6F0)
 * [Mini Pascal VOC](https://1drv.ms/u/s!AnBBK4_o1T9MdS8wbopnWowJcpM?e=VHhsFB)
@@ -213,6 +232,13 @@ dataset root.
 │   │   train.txt
 │   │   trainaug.txt
 │   │   val.txt
+```
+
+You can run the following shell commands to download and unpack the complete Pascal VOC dataset:
+
+```sh
+wget -O voc_data.zip "https://c2ymfq.am.files.1drv.com/y4mZqATCHOv_Z88obTJ_ZatMGDEx6ts5TzOyJnVLKqmkXZwdL_PKIMFLNmZR9FLFJ1CHMC6h_7bJjxlcUM8yXjG92Ms1X-95x6Dh90QgawSpYDPoE1gmLx3VwnW2amZZEog-omFd87fTKZqn3lpP_mtisDQsfDzruBgz_JHcSWsZd2jrsN2qoV3cJ5HammjY_im0ftfjwNOup1EuiWcQ9KT6A"
+unzip voc_data.zip
 ```
 
 ### Examples

--- a/eval.py
+++ b/eval.py
@@ -1,0 +1,80 @@
+import os
+import torch
+import wandb
+import random
+import argparse
+import numpy as np
+
+from src.hbird_eval import hbird_evaluation
+
+
+def main(args):
+    print(f"the script arguments are {args}")
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = torch.hub.load("facebookresearch/dino:main", args.model).to(device)
+
+    def token_features(model, imgs):
+        return model.get_intermediate_layers(imgs)[0][:, 1:], None
+
+    hbird_miou = hbird_evaluation(
+        model.to(device),
+        # Size of the embedding feature vectors of patches
+        d_model=args.embeddings_size,
+        patch_size=args.patch_size,
+        batch_size = args.batch_size,
+        input_size=args.input_size,
+        # How many iterations of augmentations to use on top of the training dataset in order to generate the memory
+        augmentation_epoch=1,
+        device=device,
+        # Whether to return additional NNs details
+        return_knn_details=False,
+        # The number of neighbors to fetch per image patch
+        num_neighbour=30,
+        # Other parameters to be used for the k-NN operator
+        nn_params=None,
+        # Function that extracts features from a vision encoder on images
+        ftr_extr_fn=token_features,
+        # The name of the dataset to use, currently only Pascal VOC is included.
+        dataset_name="voc",
+        # Path to the dataset to use for evaluation
+        data_dir=args.data_dir,
+        memory_size=args.memory_size
+    )
+
+    print(f"Hummingbird Evaluation (mIoU): {hbird_miou}")
+
+
+def seed_everything(seed: int):
+	random.seed(seed)
+	np.random.seed(seed)
+
+	os.environ["PYTHONHASHSEED"] = str(seed)
+
+	torch.manual_seed(seed)
+	torch.cuda.manual_seed_all(seed)
+
+
+if __name__ == "__main__":
+    wandb.login()
+
+    parser = argparse.ArgumentParser(description="HummingBird Evaluation")
+
+    # Standard arguments
+    parser.add_argument("--seed", default=42, type=int, help="The seed for the random number generators")
+
+    # Model arguments
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--input-size", type=int, default=224, help="Size of the images fed to the model")
+    parser.add_argument("--patch-size", type=int, default=16, help="Size of the model patches")
+    parser.add_argument("--memory-size", type=int, default=None, help="The size of the memory bank. Unbounded if not specified")
+    parser.add_argument("--model", type=str, required=True, help="DINO model name")
+    parser.add_argument("--embeddings-size", type=int, required=True, help="The size of the model embeddings")
+
+    # Data arguments
+    parser.add_argument("--data-dir", type=str, default="VOCSegmentation", help="Path to the VOC dataset")
+
+    args = parser.parse_args()
+
+    seed_everything(args.seed)
+    main(args)

--- a/eval.py
+++ b/eval.py
@@ -46,13 +46,13 @@ def main(args):
 
 
 def seed_everything(seed: int):
-	random.seed(seed)
-	np.random.seed(seed)
+    random.seed(seed)
+    np.random.seed(seed)
 
-	os.environ["PYTHONHASHSEED"] = str(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
 
-	torch.manual_seed(seed)
-	torch.cuda.manual_seed_all(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Sped up the sampling process by removing `torch.where` calls and vectorizing loops in `get_class_frequency` and `get_patch_scores `
- Added an `eval.py` script to quicky run experiments
- Minor updated in `README.md` to show how to use the `eval.py` script and quickly download the data via shell