### PR TITLE
moved pascal voc to Google Drive to avoid links from expiring

### DIFF
--- a/DATASET.md
+++ b/DATASET.md
@@ -44,9 +44,9 @@ dataset root.
 ```
 ##### VOC Pascal
 We provide you with a zipped version of the whole dataset as well as with two smaller versions of it:
-* [Pascal VOC](https://1drv.ms/u/s!AnBBK4_o1T9MbXrxhV7BpGdS8tk?e=P7G6F0)
-* [Mini Pascal VOC](https://1drv.ms/u/c/67fac29a77adbae6/EXkWjXPBLmNIgqI1G8yZzBYB_11wyXI-_8u0pyERgib8fA?e=qle36E)
-* [Tiny Pascal VOC](https://1drv.ms/u/c/67fac29a77adbae6/EbGBdN6Z9LNEt3-3FveU344BnlECl_cwueg8-getyattqA?e=HPrVa1)
+* [Pascal VOC](https://drive.google.com/uc?id=1LITii48SINBFAankzh_HlYWx5jCJzG4X)
+* [Mini Pascal VOC](https://drive.google.com/uc?id=1GoRApuZzsM8a5nTa-wyEsLPOXPJuzbcT)
+* [Tiny Pascal VOC](https://drive.google.com/uc?id=1o9evnop5BJnT47jwFk9cUp3TxHRdNpVN)
 The structure for training and evaluation should be as follows:
 ```
 dataset root.

--- a/examples/hbird_eval_example_faiss_gpu.ipynb
+++ b/examples/hbird_eval_example_faiss_gpu.ipynb
@@ -46,6 +46,8 @@
     "!pip install numpy==1.26.4\n",
     "!pip install triton==2.2.0\n",
     "!pip install faiss-gpu-cu12\n",
+    "!pip install gdown\n",
+    "\n",
     "!pip uninstall -y thinc"
    ]
   },
@@ -143,8 +145,8 @@
    },
    "outputs": [],
    "source": [
-    "# Download the tiny Pascal VOC - https://1drv.ms/u/c/67fac29a77adbae6/EbGBdN6Z9LNEt3-3FveU344BnlECl_cwueg8-getyattqA?e=HPrVa1 # tiny\n",
-    "!wget -O voc_data.zip \"<Paste the curl lnk of the onedrive object here>\""
+    "# Download the tiny Pascal VOC\n",
+    "!wget -O voc_data.zip \"https://drive.google.com/uc?id=1o9evnop5BJnT47jwFk9cUp3TxHRdNpVN\""
    ]
   },
   {
@@ -164,8 +166,8 @@
    },
    "outputs": [],
    "source": [
-    "# Download the mini Pascal VOC - https://1drv.ms/u/c/67fac29a77adbae6/EXkWjXPBLmNIgqI1G8yZzBYB_11wyXI-_8u0pyERgib8fA?e=qle36E # mini\n",
-    "!wget -O voc_data.zip \"<Paste the curl lnk of the onedrive object here>\""
+    "# Download the mini Pascal VOC\n",
+    "!wget -O voc_data.zip \"https://drive.google.com/uc?id=1GoRApuZzsM8a5nTa-wyEsLPOXPJuzbcT\""
    ]
   },
   {
@@ -185,8 +187,8 @@
    },
    "outputs": [],
    "source": [
-    "# Download the full Pascal VOC - https://1drv.ms/u/c/67fac29a77adbae6/EcilwP2YfSBGj3xvUWCu42EBfoHTmSlHz8Aw_8VgqwWd8g?e=KUFcva # full\n",
-    "!wget -O voc_data.zip \"<Paste the curl lnk of the onedrive object here>\""
+    "# Download the full Pascal VOC\n",
+    "!wget -O voc_data.zip \"https://drive.google.com/uc?id=1LITii48SINBFAankzh_HlYWx5jCJzG4X\""
    ]
   },
   {

--- a/examples/hbird_eval_example_scann.ipynb
+++ b/examples/hbird_eval_example_scann.ipynb
@@ -39,6 +39,7 @@
    "source": [
     "!pip install torchmetrics\n",
     "!pip install scann\n",
+    "!pip install gdown\n",
     "\n",
     "# !pip install torch==2.2.2 torchvision==0.17.2 torchaudio==2.2.2 --index-url https://download.pytorch.org/whl/cu121\n",
     "# !pip install lightning==2.4.0\n",
@@ -137,8 +138,8 @@
    },
    "outputs": [],
    "source": [
-    "# Download the tiny Pascal VOC - https://1drv.ms/u/c/67fac29a77adbae6/EbGBdN6Z9LNEt3-3FveU344BnlECl_cwueg8-getyattqA?e=HPrVa1 # tiny\n",
-    "!wget -O voc_data.zip \"<Paste the curl lnk of the onedrive object here>\""
+    "# Download the tiny Pascal VOC\n",
+    "!wget -O voc_data.zip \"https://drive.google.com/uc?id=1o9evnop5BJnT47jwFk9cUp3TxHRdNpVN\""
    ]
   },
   {
@@ -158,8 +159,8 @@
    },
    "outputs": [],
    "source": [
-    "# Download the mini Pascal VOC - https://1drv.ms/u/c/67fac29a77adbae6/EXkWjXPBLmNIgqI1G8yZzBYB_11wyXI-_8u0pyERgib8fA?e=qle36E # mini\n",
-    "!wget -O voc_data.zip \"<Paste the curl lnk of the onedrive object here>\""
+    "# Download the mini Pascal VOC\n",
+    "!wget -O voc_data.zip \"https://drive.google.com/uc?id=1GoRApuZzsM8a5nTa-wyEsLPOXPJuzbcT\""
    ]
   },
   {
@@ -179,8 +180,8 @@
    },
    "outputs": [],
    "source": [
-    "# Download the full Pascal VOC - https://1drv.ms/u/c/67fac29a77adbae6/EcilwP2YfSBGj3xvUWCu42EBfoHTmSlHz8Aw_8VgqwWd8g?e=KUFcva # full\n",
-    "!wget -O voc_data.zip \"<Paste the curl lnk of the onedrive object here>\""
+    "# Download the full Pascal VOC\n",
+    "!wget -O voc_data.zip \"https://drive.google.com/uc?id=1LITii48SINBFAankzh_HlYWx5jCJzG4X\""
    ]
   },
   {


### PR DESCRIPTION
Moved the Pascal VOC data files to Google Drive, so that the notebook links won't expire again